### PR TITLE
More efficient implementation of NonEmptyList

### DIFF
--- a/src/commonMain/kotlin/com/quickbirdstudios/nonEmptyCollection/list/NonEmptyList+plus.kt
+++ b/src/commonMain/kotlin/com/quickbirdstudios/nonEmptyCollection/list/NonEmptyList+plus.kt
@@ -1,26 +1,18 @@
 package com.quickbirdstudios.nonEmptyCollection.list
 
-operator fun <T> NonEmptyList<T>.plus(value: T) = copy(tail = tail + value)
+operator fun <T> NonEmptyList<T>.plus(value: T): NonEmptyList<T> = NonEmptyList(full + value)
 
-operator fun <T> List<T>.plus(value: T) = NonEmptyList(
-    head = firstOrNull() ?: value,
-    tail = (this + nonEmptyListOf(value)).drop(1)
-)
+operator fun <T> List<T>.plus(value: T): NonEmptyList<T> = NonEmptyList(this as Collection<T> + value)
 
-operator fun <T> NonEmptyList<T>.plus(other: List<T>) = copy(
-    tail = tail as Collection<T> + other
-)
+operator fun <T> NonEmptyList<T>.plus(other: List<T>): NonEmptyList<T> = NonEmptyList(full as Collection<T> + other)
 
 operator fun <T> List<T>.plus(
     other: NonEmptyList<T>
-): NonEmptyList<T> = other.copy(
-    head = this.firstOrNull() ?: other.head,
-    tail = (this as Collection<T> + other).drop(1)
-)
+): NonEmptyList<T> = NonEmptyList(this as Collection<T> + other.full)
 
 operator fun <T> NonEmptyList<T>.plus(
     other: NonEmptyList<T>
-): NonEmptyList<T> = copy(tail = tail + other)
+): NonEmptyList<T> = NonEmptyList(full as Collection<T> + other.full)
 
 operator fun <T> NonEmptyList<T>.plus(
     other: Iterable<T>

--- a/src/commonMain/kotlin/com/quickbirdstudios/nonEmptyCollection/list/NonEmptyList.kt
+++ b/src/commonMain/kotlin/com/quickbirdstudios/nonEmptyCollection/list/NonEmptyList.kt
@@ -2,12 +2,19 @@ package com.quickbirdstudios.nonEmptyCollection.list
 
 import com.quickbirdstudios.nonEmptyCollection.NonEmptyCollection
 
-data class NonEmptyList<T> internal constructor(
-    internal val head: T,
-    internal val tail: List<T>
-) : List<T> by listOf(head) as Collection<T> + tail, NonEmptyCollection<T> {
+class NonEmptyList<T> internal constructor(internal val full: List<T>) : List<T> by full, NonEmptyCollection<T> {
+    constructor(
+        head: T,
+        tail: List<T>
+    ) : this(ArrayList<T>(tail.size + 1).apply { add(head); addAll(tail) })
 
-    override fun equals(other: Any?): Boolean = toList() == other
+    init {
+        require(full.isNotEmpty()) { "Fatal Error! This is a bug. Please contact the library author." }
+    }
 
-    override fun hashCode(): Int = toList().hashCode()
+    override fun toString(): String = full.toString()
+
+    override fun equals(other: Any?): Boolean = full == other
+
+    override fun hashCode(): Int = full.hashCode()
 }


### PR DESCRIPTION
Similar to my comments on Reddit :)

Notice a few things:

* NonEmptyList only holds one reference.
* NonEmptyList.equals() is much more efficient than current main branch implementation. The main implementation is creating a new list every single time someone checks equality.
* the head, tail constructor does one allocation instead of two.
* All of the plus operators do less work. Some do significantly less work (e.g., List.plus(value): NonEmptyList).
* Since plus operations will only ever increase the size of the list, there is no need to use the "safe" constructor- which also helps the performance gains mentioned above.
* The plus operations that involve a NonEmptyList intentionally unwrap it so that we don't end up with a deeply nested object after many plus operations. This would be a space leak.

The same approach could be applied to the other collections, but I wanted to just PR this one first before wasting my time :)